### PR TITLE
Update ntapi version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2824,9 +2824,9 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.3.7"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
 dependencies = [
  "winapi",
 ]

--- a/mux/Cargo.toml
+++ b/mux/Cargo.toml
@@ -48,7 +48,7 @@ wezterm-term = { path = "../term", features=["use_serde"] }
 flume = "0.10"
 
 [target."cfg(windows)".dependencies]
-ntapi = "0.3"
+ntapi = "0.4"
 winapi = { version = "0.3", features = [
     "handleapi",
     "memoryapi",

--- a/procinfo/Cargo.toml
+++ b/procinfo/Cargo.toml
@@ -15,7 +15,7 @@ luahelper = { path = "../luahelper", optional = true }
 wezterm-dynamic = { path = "../wezterm-dynamic", optional = true }
 
 [target."cfg(windows)".dependencies]
-ntapi = "0.3"
+ntapi = "0.4"
 winapi = { version = "0.3", features = [
     "handleapi",
     "memoryapi",


### PR DESCRIPTION
This is a solution to Windows build errors (Refs: zed-industries/zed#7696)

Because upstream wezterm has already upgreaded this dependency, it could solve merge upstream to this fork.
But I cannot check that the regression is not occurring on macOS, I made the changes small enough to have no impact.